### PR TITLE
Add xcconfig parameters to generated targets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cocoapods-bazel (0.1.0)
-      starlark_compiler (~> 0.2)
+      starlark_compiler (~> 0.3)
 
 GEM
   remote: https://rubygems.org/
@@ -98,7 +98,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-macho (1.4.0)
     ruby-progressbar (1.10.1)
-    starlark_compiler (0.2.0)
+    starlark_compiler (0.3.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -122,4 +122,4 @@ DEPENDENCIES
   rubocop (~> 0.78)
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/lib/cocoapods/bazel.rb
+++ b/lib/cocoapods/bazel.rb
@@ -3,11 +3,17 @@
 require 'starlark_compiler/build_file'
 require 'cocoapods/bazel/config'
 require 'cocoapods/bazel/target'
+require 'cocoapods/bazel/xcconfig_resolver'
 
 module Pod
   module Bazel
     def self.post_install(installer:)
       return unless (config = Config.from_podfile(installer.podfile))
+
+      default_xcconfigs = config.default_xcconfigs.transform_values do |xcconfig|
+        _name, xcconfig = XCConfigResolver.resolve_xcconfig(xcconfig)
+        xcconfig
+      end
 
       UI.titled_section 'Generating Bazel files' do
         workspace = installer.config.installation_root
@@ -17,8 +23,8 @@ module Pod
           package = sandbox.pod_dir(pod_target.pod_name).relative_path_from(workspace).to_s
           build_file = build_files[package]
 
-          bazel_targets = [Target.new(installer, pod_target)] +
-                          pod_target.file_accessors.reject { |fa| fa.spec.library_specification? }.map { |fa| Target.new(installer, pod_target, fa.spec) }
+          bazel_targets = [Target.new(installer, pod_target, nil, default_xcconfigs)] +
+                          pod_target.file_accessors.reject { |fa| fa.spec.library_specification? }.map { |fa| Target.new(installer, pod_target, fa.spec, default_xcconfigs) }
 
           bazel_targets.each do |t|
             load = config.load_for(macro: t.type)
@@ -26,6 +32,27 @@ module Pod
             build_file.add_target StarlarkCompiler::AST::FunctionCall.new(load[:rule], **t.to_rule_kwargs)
           end
         end
+
+        unless default_xcconfigs.empty?
+          hash = StarlarkCompiler::AST.new(toplevel: [
+                                             StarlarkCompiler::AST::Dictionary.new(default_xcconfigs)
+                                           ])
+
+          pkg = File.join(sandbox.root, 'cocoapods-bazel')
+          FileUtils.mkdir_p pkg
+          FileUtils.touch(File.join(pkg, 'BUILD.bazel'))
+          File.open(File.join(pkg, 'default_xcconfigs.bzl'), 'w') do |f|
+            f << <<~STARLARK
+              """
+              Default xcconfigs given as options to cocoapods-bazel.
+              """
+
+            STARLARK
+            f << 'DEFAULT_XCCONFIGS = '
+            StarlarkCompiler::Writer.write(ast: hash, io: f)
+          end
+        end
+
         build_files.each_value(&:save!)
         format_files(build_files: build_files, buildifier: config.buildifier, workspace: workspace)
       end

--- a/lib/cocoapods/bazel/config.rb
+++ b/lib/cocoapods/bazel/config.rb
@@ -12,7 +12,8 @@ module Pod
           'ios_unit_test' => { load: '@build_bazel_rules_ios//rules:test.bzl', rule: 'ios_unit_test' }.freeze
         }.freeze,
         overrides: {}.freeze,
-        buildifier: true
+        buildifier: true,
+        default_xcconfigs: {}.freeze
       }.with_indifferent_access.freeze
       private_constant :DEFAULTS
 
@@ -49,6 +50,10 @@ module Pod
 
       def load_for(macro:)
         to_h.dig('rules', macro) || raise("no rule configured for #{macro}")
+      end
+
+      def default_xcconfigs
+        to_h[:default_xcconfigs]
       end
     end
   end

--- a/lib/cocoapods/bazel/target.rb
+++ b/lib/cocoapods/bazel/target.rb
@@ -194,9 +194,10 @@ module Pod
         end
 
         # non-propagated stuff
-        kwargs[:swift_copts] = resolved_build_setting_value('OTHER_SWIFT_FLAGS')&.shellsplit || []
-        kwargs[:objc_copts] = resolved_build_setting_value('OTHER_CFLAGS')&.shellsplit || []
-        # kwargs[:cc_copts] = resolve_string_with_build_settings('${OTHER_CFLAGS} ${OTHER_CPPFLAGS}')&.shellsplit || []
+        kwargs[:swift_copts] = resolved_build_setting_value('OTHER_SWIFT_FLAGS') || []
+        kwargs[:objc_copts] = resolved_build_setting_value('OTHER_CFLAGS') || []
+        kwargs[:linkopts] = resolved_build_setting_value('OTHER_LDFLAGS') || []
+        # kwargs[:cc_copts] = resolved_build_setting_value('${OTHER_CFLAGS} ${OTHER_CPPFLAGS}') || []
 
         # propagated
         kwargs[:defines] = []

--- a/lib/cocoapods/bazel/xcconfig_resolver.rb
+++ b/lib/cocoapods/bazel/xcconfig_resolver.rb
@@ -30,11 +30,11 @@ module Pod
           (config.keys - xcconfig.keys).empty?
         end
 
-        xcconfig.delete_if do |k, _|
-          %w[OTHER_CFLAGS OTHER_SWIFT_FLAGS SWIFT_VERSION SDKROOT CONFIGURATION PODS_TARGET_SRCROOT SRCROOT].include?(k)
-        end
         xcconfig.each_key { |k| xcconfig[k] = resolved_build_setting_value(k, settings: xcconfig) }
-        xcconfig.delete_if { |_, v| v.empty? }
+        xcconfig.delete_if do |k, v|
+          %w[OTHER_CFLAGS OTHER_SWIFT_FLAGS SWIFT_VERSION SDKROOT CONFIGURATION PODS_TARGET_SRCROOT SRCROOT].include?(k) ||
+            v.empty?
+        end
 
         unless matching_defaults.empty?
           transformed = matching_defaults.map do |name, default_config|

--- a/lib/cocoapods/bazel/xcconfig_resolver.rb
+++ b/lib/cocoapods/bazel/xcconfig_resolver.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Pod
+  module Bazel
+    module XCConfigResolver
+      module_function
+
+      def resolved_build_setting_value(setting, settings:)
+        return unless (value = settings[setting])
+
+        sub_prefix = ->(s) { s.sub(%r{\A:/}, '') }
+        resolved = resolve_string_with_build_settings(value, settings: settings)
+        if Pod::Target::BuildSettings::PLURAL_SETTINGS.include?(setting)
+          resolved.shellsplit.reject(&:empty?).map(&sub_prefix)
+        else
+          sub_prefix[resolved]
+        end
+      end
+
+      def resolve_string_with_build_settings(string, settings:)
+        return string unless string =~ /\$(?:\{([_a-zA-Z0-0]+?)\}|\(([_a-zA-Z0-0]+?)\))/
+
+        match, key = Regexp.last_match.values_at(0, 1, 2).compact
+        sub = settings.fetch(key, '')
+        resolve_string_with_build_settings(string.gsub(match, sub), settings: settings)
+      end
+
+      def resolve_xcconfig(xcconfig, default_xcconfigs: [])
+        matching_defaults = default_xcconfigs.select do |_, config|
+          (config.keys - xcconfig.keys).empty?
+        end
+
+        xcconfig.delete_if do |k, _|
+          %w[OTHER_CFLAGS OTHER_SWIFT_FLAGS SWIFT_VERSION SDKROOT CONFIGURATION PODS_TARGET_SRCROOT SRCROOT].include?(k)
+        end
+        xcconfig.each_key { |k| xcconfig[k] = resolved_build_setting_value(k, settings: xcconfig) }
+        xcconfig.delete_if { |_, v| v.empty? }
+
+        unless matching_defaults.empty?
+          transformed = matching_defaults.map do |name, default_config|
+            [name, xcconfig.reject do |k, v|
+              v == default_config[k]
+            end]
+          end
+          name, xcconfig = transformed.min_by { |(_, config)| config.size }
+        end
+
+        [name, xcconfig]
+      end
+    end
+  end
+end

--- a/spec/cocoapods/bazel/xcconfig_resolver_spec.rb
+++ b/spec/cocoapods/bazel/xcconfig_resolver_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+RSpec.describe Pod::Bazel::XCConfigResolver do
+  it 'resolves empty xcconfigs' do
+    default_config_name, resolved = described_class.resolve_xcconfig({})
+    expect(default_config_name).to be_nil
+    expect(resolved).to eq({})
+  end
+
+  it 'resolves xcconfigs' do
+    default_config_name, resolved = described_class.resolve_xcconfig(
+      'ENABLE_TESTABILITY_Debug' => 'YES',
+      'ENABLE_TESTABILITY_Release' => 'NO',
+      'ENABLE_TESTABILITY' => '$(ENABLE_TESTABILITY_$(CONFIGURATION))',
+
+      'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) foo bar=1 "baz=${ENABLE_TESTABILITY}"',
+
+      'CONFIGURATION' => 'Debug'
+    )
+    expect(default_config_name).to be_nil
+    expect(resolved).to eq(
+      'ENABLE_TESTABILITY' => 'YES',
+      'ENABLE_TESTABILITY_Debug' => 'YES',
+      'ENABLE_TESTABILITY_Release' => 'NO',
+
+      'GCC_PREPROCESSOR_DEFINITIONS' => ['foo', 'bar=1', 'baz=YES'],
+    )
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require 'bundler/setup'
 
 require 'cocoapods'
+require 'cocoapods/bazel'
 
 #-----------------------------------------------------------------------------#
 


### PR DESCRIPTION
This PR is focused on serializing xcconfigs into targets (meant to be paired with https://github.com/ob/rules_ios/pull/23). The goal is enabling targets to be compiled with (as close to) the same set of compiler flags as is done via Xcode/CocoaPods.

At it's core, this is pretty simple -- we serialize the (pod target) xcconfig as a dict parameter to the macro invocation, and it's responsible for resolving the build settings. 

To make it so we're serializing easily-interpreted configs, though, we allow the Podfile configuration to specify a list of "default" configurations. If a default configuration matches a pod's xcconfig, we serialize the name of the matching config (so the rules can underlay that xcconfig underneath the per-library xcconfig), and remove all the matching xcconfig settings (so we only serialize the minimum amount necessary). 